### PR TITLE
Wayland fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Look for your NVidia GPU and note the device id
 set -x
 
 # Shut down display to release GPU
-optimus-manager --no-confirm --switch integrated
+# Put Y in the stdin to avoid prompting for confirmation if using wayland
+optimus-manager --no-confirm --switch integrated <<< "Y"
 systemctl stop display-manager.service
 
 # Unload NVidia

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ modprobe nvidia_modeset
 modprobe nvidia
 
 # Restart session with GPU set to Hybrid
-optimus-manager --no-confirm --switch hybrid
+# Put Y in the stdin to avoid prompting for confirmation if using wayland
+optimus-manager --no-confirm --switch hybrid <<< "Y"
 systemctl restart display-manager.service
 ```
 


### PR DESCRIPTION
For some reason --no-confirm doesn't work for Optimus-Manager's warning about wayland. This can be solved by inserting Y in the stdin